### PR TITLE
Added cross-browser support

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>HTML Text Editor</title>
-
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.min.js"></script>
   <script type="text/javascript" src="scripts/script.js"></script>
   <link type="text/css" rel="stylesheet" href="stylesheets/styles.css">
 </head>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,19 +1,9 @@
-//this function based off of thiscouldbebetter.wordpress.com/2012/12/18/loading-editing-and-saving-a-text-file-in-html5-using-javascrip/
 function downloadText() {
 	var fileText = document.getElementById("workspace").value;
-	var textFileBlob = new Blob([fileText], {type:'text/plain'});
-	var FileDownloadName = document.getElementById("fileName").value;
+	var fileDownloadName = document.getElementById("fileName").value;
 
-	var downloadLink = document.createElement("a");
-	downloadLink.download = FileDownloadName;
-
-		// Chrome allows the link to be clicked
-		// without actually adding it to the DOM.
-		downloadLink.href = window.webkitURL.createObjectURL(textFileBlob);
-
-
-
-	downloadLink.click();
+	var blob = new Blob([fileText], {type: "text/plain;charset=utf-8"});
+	saveAs(blob, fileDownloadName);
 }
 
 function setStyle() {


### PR DESCRIPTION
This PR will resolve #7. I tested the existing code but found out that it use the `download` attribute on anchor tags, which are used to download a link to a specified file. Although the attribute is supported in most browsers, it is (according to http://caniuse.com/#feat=download) unsupported by Internet Explorer and Safari (available in development versions). It would be possible to create support for Internet Explorer for example using `window.navigator.msSaveBlob` but that would require User-Agent checking and does not resolve the issues for the other unsupported browsers. At this point it is easier to include an external library like [`FileSaver.js`](https://github.com/eligrey/FileSaver.js/) that includes the necessary compatibility code and enables a clean way to use. I included this library through a CDN which delivers the minified scripts and adjusted the existing code.